### PR TITLE
feat(add): terraform-lsp

### DIFF
--- a/coc-settings.json
+++ b/coc-settings.json
@@ -1,0 +1,14 @@
+{
+	"languageserver": {
+		"terraform": {
+			"command": "terraform-ls",
+			"args": ["serve"],
+			"filetypes": [
+				"terraform",
+				"tf"
+			],
+			"initializationOptions": {},
+			"settings": {}
+		}
+	}
+}

--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,7 @@
 -- global settings
 vim.g.mapleader = ","
 local opt = vim.opt
+local keyset = vim.keymap.set
 opt.number = true
 opt.relativenumber = true
 opt.hlsearch = true
@@ -12,6 +13,24 @@ opt.shiftwidth = 2
 opt.smartindent = true
 opt.clipboard = "unnamedplus"
 vim.cmd('colorscheme gruvbox')
+
+-- COC Autocomplete
+function _G.check_back_space()
+    local col = vim.fn.col('.') - 1
+    return col == 0 or vim.fn.getline('.'):sub(col, col):match('%s') ~= nil
+end
+
+-- Use Tab for trigger completion with characters ahead and navigate
+-- NOTE: There's always a completion item selected by default, you may want to enable
+-- no select by setting `"suggest.noselect": true` in your configuration file
+-- NOTE: Use command ':verbose imap <tab>' to make sure Tab is not mapped by
+-- other plugins before putting this into your config
+local opts = {silent = true, noremap = true, expr = true, replace_keycodes = false}
+keyset("i", "<TAB>", 'coc#pum#visible() ? coc#pum#next(1) : v:lua.check_back_space() ? "<TAB>" : coc#refresh()', opts)
+keyset("i", "<S-TAB>", [[coc#pum#visible() ? coc#pum#prev(1) : "\<C-h>"]], opts)
+-- Make <CR> to accept selected completion item or notify coc.nvim to format
+-- <C-g>u breaks current undo, please make your own choice
+keyset("i", "<cr>", [[coc#pum#visible() ? coc#pum#confirm() : "\<C-g>u\<CR>\<c-r>=coc#on_enter()\<CR>"]], opts)
 
 -- (fancy) Remaps
 -- while in 'visual line' mode i can move the highlighted text around with 'J' and 'K'


### PR DESCRIPTION
Adding terraform LSP to neovim. `terraform-ls` needs to be installed on the machine. Selecting is possible via `Tab`, confirm the selection via `Enter`.